### PR TITLE
feat: 添加对 Markdown 文件的支持并更新依赖项

### DIFF
--- a/apps/web/env.d.ts
+++ b/apps/web/env.d.ts
@@ -1,2 +1,16 @@
 /// <reference types="vite/client" />
 /// <reference types="unplugin-vue-router/client" />
+
+declare module '*.vue' {
+  import type { ComponentOptions } from 'vue'
+
+  const Component: ComponentOptions
+  export default Component
+}
+
+declare module '*.md' {
+  import type { ComponentOptions } from 'vue'
+
+  const Component: ComponentOptions
+  export default Component
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,6 +16,7 @@
     "format": "prettier --write src/"
   },
   "dependencies": {
+    "@pkg/content": "workspace:*",
     "@pkg/utils": "workspace:*",
     "pinia": "^3.0.3",
     "vue": "^3.5.22"
@@ -26,7 +27,6 @@
     "@pkg/typescript-config": "workspace:*",
     "@vitejs/plugin-vue": "^6.0.1",
     "@vitejs/plugin-vue-jsx": "^5.0.1",
-    "@vueuse/head": "^2.0.0",
     "jiti": "^2.6.0",
     "npm-run-all2": "^8.0.4",
     "vite": "^7.1.7",

--- a/apps/web/src/main.ts
+++ b/apps/web/src/main.ts
@@ -3,12 +3,17 @@ import './assets/main.css'
 import App from './App.vue'
 import { ViteSSG } from 'vite-ssg'
 import { createPinia } from 'pinia'
-import { routes } from 'vue-router/auto-routes' // 改成你拆分出的 routes 檔案
+import { routes } from 'vue-router/auto-routes'
+import { createHead } from '@unhead/vue/client'
 
 export const createApp = ViteSSG(App, { routes }, ({ app, router, initialState }) => {
-  // 這裡可以註冊 Pinia
+  // Pinia
   const pinia = createPinia()
   app.use(pinia)
+
+  // unhead
+  const head = createHead()
+  app.use(head)
 
   // 如果有其他 plugin 也可以在這裡用
   // app.use(SomeOtherPlugin)

--- a/apps/web/src/views/ArticleView.vue
+++ b/apps/web/src/views/ArticleView.vue
@@ -1,1 +1,5 @@
-<template>1234789</template>
+<script setup lang="ts">
+import Test from '@pkg/content/articles/Test.md'
+</script>
+
+<template><Test /></template>

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -5,6 +5,7 @@ import vue from '@vitejs/plugin-vue'
 import vueJsx from '@vitejs/plugin-vue-jsx'
 import vueDevTools from 'vite-plugin-vue-devtools'
 import vueRouter from 'unplugin-vue-router/vite'
+import Markdown from 'unplugin-vue-markdown/vite'
 
 import path from 'node:path'
 
@@ -15,6 +16,9 @@ export default defineConfig({
       routesFolder: ['src/views'],
     }),
     vue({ include: [/\.vue$/, /\.md$/] }),
+    Markdown({
+      headEnabled: true,
+    }),
     vueJsx(),
     vueDevTools(),
   ],

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "packages/*"
   ],
   "dependencies": {
+    "@unhead/vue": "^2.0.17",
     "@vitejs/plugin-vue": "^6.0.1",
     "fs-extra": "^11.3.2",
     "gray-matter": "^4.0.3",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@vitejs/plugin-vue": "^6.0.1",
     "fs-extra": "^11.3.2",
     "gray-matter": "^4.0.3",
-    "unplugin-vue-markdown": "^29.2.0"
+    "unplugin-vue-markdown": "^29.2.0",
+    "vue": "^3.5.22"
   }
 }

--- a/packages/content/articles/Test.md
+++ b/packages/content/articles/Test.md
@@ -1,0 +1,10 @@
+---
+title: My Cool App
+meta:
+  - name: description
+    content: Hello World
+---
+
+# 這是第一篇文章
+
+第一篇內文

--- a/packages/content/package.json
+++ b/packages/content/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "content",
+  "name": "@pkg/content",
   "version": "1.0.0",
   "description": "",
   "private": true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@unhead/vue':
+        specifier: ^2.0.17
+        version: 2.0.17(vue@3.5.22(typescript@5.9.2))
       '@vitejs/plugin-vue':
         specifier: ^6.0.1
         version: 6.0.1(vite@7.1.7(@types/node@24.6.0)(jiti@2.6.0)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1))(vue@3.5.22(typescript@5.9.2))
@@ -106,6 +109,9 @@ importers:
 
   apps/web:
     dependencies:
+      '@pkg/content':
+        specifier: workspace:*
+        version: link:../../packages/content
       '@pkg/utils':
         specifier: workspace:*
         version: link:../../packages/utils
@@ -131,9 +137,6 @@ importers:
       '@vitejs/plugin-vue-jsx':
         specifier: ^5.0.1
         version: 5.1.1(vite@7.1.7(@types/node@24.6.0)(jiti@2.6.0)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1))(vue@3.5.22(typescript@5.9.2))
-      '@vueuse/head':
-        specifier: ^2.0.0
-        version: 2.0.0(vue@3.5.22(typescript@5.9.2))
       jiti:
         specifier: ^2.6.0
         version: 2.6.0
@@ -973,27 +976,10 @@ packages:
     resolution: {integrity: sha512-qsaFBA3e09MIDAGFUrTk+dzqtfv1XPVz8t8d1f0ybTzrCY7BKiMC5cjrl1O/P7UmHsNyW90EYSkU/ZWpmXelag==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@unhead/dom@1.11.20':
-    resolution: {integrity: sha512-jgfGYdOH+xHJF/j8gudjsYu3oIjFyXhCWcgKaw3vQnT616gSqyqnGQGOItL+BQtQZACKNISwIfx5PuOtztMKLA==}
-
   '@unhead/dom@2.0.17':
     resolution: {integrity: sha512-EV8ze/Nhg/PhIQoplrfCXrY7iLBiVQZYNsj0DYDm2lg3hOD5igbAmgppxcr7zdZh1DYvn+KhXoRzlSUGpYR3ug==}
     peerDependencies:
       unhead: 2.0.17
-
-  '@unhead/schema@1.11.20':
-    resolution: {integrity: sha512-0zWykKAaJdm+/Y7yi/Yds20PrUK7XabLe9c3IRcjnwYmSWY6z0Cr19VIs3ozCj8P+GhR+/TI2mwtGlueCEYouA==}
-
-  '@unhead/shared@1.11.20':
-    resolution: {integrity: sha512-1MOrBkGgkUXS+sOKz/DBh4U20DNoITlJwpmvSInxEUNhghSNb56S0RnaHRq0iHkhrO/cDgz2zvfdlRpoPLGI3w==}
-
-  '@unhead/ssr@1.11.20':
-    resolution: {integrity: sha512-j6ehzmdWGAvv0TEZyLE3WBnG1ULnsbKQcLqBDh3fvKS6b3xutcVZB7mjvrVE7ckSZt6WwOtG0ED3NJDS7IjzBA==}
-
-  '@unhead/vue@1.11.20':
-    resolution: {integrity: sha512-sqQaLbwqY9TvLEGeq8Fd7+F2TIuV3nZ5ihVISHjWpAM3y7DwNWRU7NmT9+yYT+2/jw1Vjwdkv5/HvDnvCLrgmg==}
-    peerDependencies:
-      vue: '>=2.7 || >=3'
 
   '@unhead/vue@2.0.17':
     resolution: {integrity: sha512-jzmGZYeMAhETV6qfetmLbZzUjjx1TjdNvFSobeFZb73D7dwD9wl/nOAx36qq+TvjZsLJdF5PQWToz2oDGAUqCg==}
@@ -1135,11 +1121,6 @@ packages:
         optional: true
       vue:
         optional: true
-
-  '@vueuse/head@2.0.0':
-    resolution: {integrity: sha512-ykdOxTGs95xjD4WXE4na/umxZea2Itl0GWBILas+O4oqS7eXIods38INvk3XkJKjqMdWPcpCyLX/DioLQxU1KA==}
-    peerDependencies:
-      vue: '>=2.7 || >=3'
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -1941,9 +1922,6 @@ packages:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
 
-  packrup@0.1.2:
-    resolution: {integrity: sha512-ZcKU7zrr5GlonoS9cxxrb5HVswGnyj6jQvwFBa6p5VFw7G71VAHcUKL5wyZSU/ECtPM/9gacWxy2KFQKt1gMNA==}
-
   param-case@3.0.4:
     resolution: {integrity: sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==}
 
@@ -2359,9 +2337,6 @@ packages:
   undici-types@7.13.0:
     resolution: {integrity: sha512-Ov2Rr9Sx+fRgagJ5AX0qvItZG/JKKoBRAVITs1zk7IqZGTJUwgUr7qoYBpWwakpWilTZFM98rG/AFRocu10iIQ==}
 
-  unhead@1.11.20:
-    resolution: {integrity: sha512-3AsNQC0pjwlLqEYHLjtichGWankK8yqmocReITecmpB1H0aOabeESueyy+8X1gyJx4ftZVwo9hqQ4O3fPWffCA==}
-
   unhead@2.0.17:
     resolution: {integrity: sha512-xX3PCtxaE80khRZobyWCVxeFF88/Tg9eJDcJWY9us727nsTC7C449B8BUfVBmiF2+3LjPcmqeoB2iuMs0U4oJQ==}
 
@@ -2618,9 +2593,6 @@ packages:
   yoctocolors@2.1.2:
     resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
     engines: {node: '>=18'}
-
-  zhead@2.2.4:
-    resolution: {integrity: sha512-8F0OI5dpWIA5IGG5NHUg9staDwz/ZPxZtvGVf01j7vHqSyZ0raHY+78atOVxRqb73AotX22uV1pXt3gYSstGag==}
 
 snapshots:
 
@@ -3363,37 +3335,9 @@ snapshots:
       '@typescript-eslint/types': 8.45.0
       eslint-visitor-keys: 4.2.1
 
-  '@unhead/dom@1.11.20':
-    dependencies:
-      '@unhead/schema': 1.11.20
-      '@unhead/shared': 1.11.20
-
   '@unhead/dom@2.0.17(unhead@2.0.17)':
     dependencies:
       unhead: 2.0.17
-
-  '@unhead/schema@1.11.20':
-    dependencies:
-      hookable: 5.5.3
-      zhead: 2.2.4
-
-  '@unhead/shared@1.11.20':
-    dependencies:
-      '@unhead/schema': 1.11.20
-      packrup: 0.1.2
-
-  '@unhead/ssr@1.11.20':
-    dependencies:
-      '@unhead/schema': 1.11.20
-      '@unhead/shared': 1.11.20
-
-  '@unhead/vue@1.11.20(vue@3.5.22(typescript@5.9.2))':
-    dependencies:
-      '@unhead/schema': 1.11.20
-      '@unhead/shared': 1.11.20
-      hookable: 5.5.3
-      unhead: 1.11.20
-      vue: 3.5.22(typescript@5.9.2)
 
   '@unhead/vue@2.0.17(vue@3.5.22(typescript@5.9.2))':
     dependencies:
@@ -3607,14 +3551,6 @@ snapshots:
   '@vue/tsconfig@0.8.1(typescript@5.9.2)(vue@3.5.22(typescript@5.9.2))':
     optionalDependencies:
       typescript: 5.9.2
-      vue: 3.5.22(typescript@5.9.2)
-
-  '@vueuse/head@2.0.0(vue@3.5.22(typescript@5.9.2))':
-    dependencies:
-      '@unhead/dom': 1.11.20
-      '@unhead/schema': 1.11.20
-      '@unhead/ssr': 1.11.20
-      '@unhead/vue': 1.11.20(vue@3.5.22(typescript@5.9.2))
       vue: 3.5.22(typescript@5.9.2)
 
   acorn-jsx@5.3.2(acorn@8.15.0):
@@ -4404,8 +4340,6 @@ snapshots:
     dependencies:
       p-limit: 3.1.0
 
-  packrup@0.1.2: {}
-
   param-case@3.0.4:
     dependencies:
       dot-case: 3.0.4
@@ -4723,13 +4657,6 @@ snapshots:
 
   undici-types@7.13.0: {}
 
-  unhead@1.11.20:
-    dependencies:
-      '@unhead/dom': 1.11.20
-      '@unhead/schema': 1.11.20
-      '@unhead/shared': 1.11.20
-      hookable: 5.5.3
-
   unhead@2.0.17:
     dependencies:
       hookable: 5.5.3
@@ -4988,5 +4915,3 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   yoctocolors@2.1.2: {}
-
-  zhead@2.2.4: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       unplugin-vue-markdown:
         specifier: ^29.2.0
         version: 29.2.0(vite@7.1.7(@types/node@24.6.0)(jiti@2.6.0)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1))
+      vue:
+        specifier: ^3.5.22
+        version: 3.5.22(typescript@5.9.2)
     devDependencies:
       '@tailwindcss/postcss':
         specifier: ^4.1.13


### PR DESCRIPTION
- 在 env.d.ts 中声明对 .vue 和 .md 文件的模块支持
- 在 main.ts 中引入并使用 @unhead/vue 进行头部管理
- 更新 package.json 以包含 @pkg/content 依赖
- 新增 Test.md 文件作为示例文章
- 移除不再使用的 @vueuse/head 依赖